### PR TITLE
Ensure that the loaded config survives an application reload

### DIFF
--- a/lib/deferred_config.ex
+++ b/lib/deferred_config.ex
@@ -109,11 +109,11 @@ defmodule DeferredConfig do
     end)
   end
 
-  @doc "`Application.put_env/3` for config kvlist"
+  @doc "`Application.put_env/4` for config kvlist"
   def apply_transformed_cfg!(kvlist, app) do
     kvlist
     |> Enum.each(fn {k,v} ->
-      Application.put_env(app, k, v)
+      Application.put_env(app, k, v, persistent: true)
     end)
   end
 


### PR DESCRIPTION
Pass `persistent: true` to `Application.put_env/4`, so that the new config values will survive the application load and reload events.

Documented [here](https://hexdocs.pm/elixir/Application.html#put_env/4). As example, it's used by [`Mix.Config.persist/1`](https://github.com/elixir-lang/elixir/blob/v1.4.5/lib/mix/lib/mix/config.ex#L237-L244).